### PR TITLE
Fix for errors with resource closure and time sync on tahoe

### DIFF
--- a/Sharktopoda.xcodeproj/project.pbxproj
+++ b/Sharktopoda.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		D305DEB62F3EAB9800ED6306 /* Sharktopoda.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Sharktopoda.xctestplan; sourceTree = "<group>"; };
 		E200F268294B7EFA004AEBF9 /* OpenMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenMainView.swift; sourceTree = "<group>"; };
 		E2020D722926E8AE0090B60B /* SharktopodaAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharktopodaAppDelegate.swift; sourceTree = "<group>"; };
 		E2020D76292834770090B60B /* VideoControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoControlView.swift; sourceTree = "<group>"; };
@@ -591,6 +592,7 @@
 		E2C22E7828CFDC26003CD976 = {
 			isa = PBXGroup;
 			children = (
+				D305DEB62F3EAB9800ED6306 /* Sharktopoda.xctestplan */,
 				E2C22E8328CFDC26003CD976 /* Sharktopoda */,
 				E2C22E9528CFDC28003CD976 /* SharktopodaTests */,
 				E2C22E9F28CFDC28003CD976 /* SharktopodaUITests */,

--- a/Sharktopoda.xcodeproj/project.pbxproj
+++ b/Sharktopoda.xcodeproj/project.pbxproj
@@ -1254,7 +1254,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.mbari.Sharktopoda2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1288,7 +1288,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.mbari.Sharktopoda2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Sharktopoda.xctestplan
+++ b/Sharktopoda.xctestplan
@@ -1,0 +1,38 @@
+{
+  "configurations" : [
+    {
+      "id" : "5776494B-C6A9-4AA1-B86E-B88FC3A31794",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "performanceAntipatternCheckerEnabled" : true,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:Sharktopoda.xcodeproj",
+      "identifier" : "E2C22E8028CFDC26003CD976",
+      "name" : "Sharktopoda"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:Sharktopoda.xcodeproj",
+        "identifier" : "E2C22E9128CFDC28003CD976",
+        "name" : "SharktopodaTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:Sharktopoda.xcodeproj",
+        "identifier" : "E2C22E9B28CFDC28003CD976",
+        "name" : "SharktopodaUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Sharktopoda/Model/SharktopodaDataLatestVideo.swift
+++ b/Sharktopoda/Model/SharktopodaDataLatestVideo.swift
@@ -15,14 +15,14 @@ extension SharktopodaData {
   }
   
   func releaseWindow(_ videoWindow: VideoWindow) {
-    videoWindow.windowData.player.replaceCurrentItem(with: nil)
-    videoWindows.removeValue(forKey: videoWindow.id)
-    
+    let id = videoWindow.id
+    videoWindows.removeValue(forKey: id)
+
     let nextLatest = latestVideoWindow()
-    
+
     Task {
-      await releaseVideo(id: videoWindow.id)
-      
+      await openVideos.close(id: id)
+
       if let latestVideoWindow = nextLatest {
         await latestVideoWindow.bringToFront()
       } else {

--- a/Sharktopoda/Model/SharktopodaDataOpenVideo.swift
+++ b/Sharktopoda/Model/SharktopodaDataOpenVideo.swift
@@ -37,11 +37,6 @@ extension SharktopodaData {
   
   func releaseVideo(id: String) async {
     await openVideos.close(id: id)
-    
-    guard let videoWindow = videoWindows[id] else { return }
-    
-    await videoWindow.windowData.player.replaceCurrentItem(with: nil)
-    await videoWindows.removeValue(forKey: videoWindow.id)
   }
 }
 

--- a/Sharktopoda/View/Video/VideoView/ControlView/Time/NSTimeSlider.swift
+++ b/Sharktopoda/View/Video/VideoView/ControlView/Time/NSTimeSlider.swift
@@ -7,6 +7,7 @@
 
 import AppKit
 import AVFoundation
+import Combine
 import SwiftUI
 
 final class NSTimeSlider: NSView {
@@ -17,26 +18,30 @@ final class NSTimeSlider: NSView {
 
   /// Hold current player direction during slider scrubbing
   var playerDirection: WindowData.PlayerDirection?
-  
+
+  var playerTimeSubscription: AnyCancellable?
+
   var windowData: WindowData {
     get { _windowData! }
     set { attach(windowData: newValue) }
   }
-  
+
   func attach(windowData: WindowData) {
     _windowData = windowData
-    
+
     frame = NSRect(x: 0, y: 0, width: windowData.videoAsset.fullSize.width, height: 40)
 
-    guard let playerItem = windowData.videoControl.currentItem else { return }
-    let syncLayer = AVSynchronizedLayer(playerItem: playerItem)
-    
     wantsLayer = true
-    layer?.addSublayer(syncLayer)
-    
-    addMarkerLayer(to: syncLayer)
+
+    addMarkerLayer()
+
+    playerTimeSubscription = windowData.$playerTime
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] time in
+        self?.updateMarkerPosition(for: time)
+      }
   }
-  
+
   var radius: CGFloat {
     NSHeight(bounds) / 2
   }
@@ -51,26 +56,30 @@ final class NSTimeSlider: NSView {
     horizontalLine.stroke()  // draw line
   }
 
-  private func addMarkerLayer(to syncLayer: AVSynchronizedLayer) {
+  private func addMarkerLayer() {
     markerLayer.frame = NSRect(x: 0, y: 0, width: radius, height: radius)
     markerLayer.cornerRadius = radius / 2
     markerLayer.backgroundColor = NSColor.systemGray.cgColor
-    syncLayer.addSublayer(markerLayer)
+    layer?.addSublayer(markerLayer)
+  }
+
+  func updateMarkerPosition(for time: CMTime) {
+    let duration = windowData.videoAsset.duration.seconds
+    guard duration > 0 else { return }
+
+    let fraction = time.seconds / duration
+    let halfWidth = markerLayer.bounds.width / 2
+    let trackWidth = bounds.width - markerLayer.bounds.width
+    let xPosition = halfWidth + CGFloat(fraction) * trackWidth
+
+    CATransaction.begin()
+    CATransaction.setDisableActions(true)
+    markerLayer.position = CGPoint(x: xPosition, y: markerLayer.position.y)
+    CATransaction.commit()
   }
 
   func setupControlViewAnimation() {
-    markerLayer.removeAllAnimations()
-    
-    let halfWidth = markerLayer.bounds.width / 2
-    
-    let slideAnimation = CABasicAnimation(keyPath: "position.x")
-    slideAnimation.fromValue = halfWidth
-    slideAnimation.toValue = layer!.bounds.width - halfWidth
-    slideAnimation.isRemovedOnCompletion = false
-    slideAnimation.beginTime = AVCoreAnimationBeginTimeAtZero
-    slideAnimation.duration = CFTimeInterval(windowData.videoAsset.duration.seconds)
-    
-    markerLayer.add(slideAnimation, forKey: windowData.id)
+    updateMarkerPosition(for: windowData.videoControl.currentTime)
   }
-  
+
 }

--- a/Sharktopoda/View/Video/VideoView/ControlView/Time/NSTimeSlider.swift
+++ b/Sharktopoda/View/Video/VideoView/ControlView/Time/NSTimeSlider.swift
@@ -72,10 +72,9 @@ final class NSTimeSlider: NSView {
     let trackWidth = bounds.width - markerLayer.bounds.width
     let xPosition = halfWidth + CGFloat(fraction) * trackWidth
 
-    CATransaction.begin()
-    CATransaction.setDisableActions(true)
-    markerLayer.position = CGPoint(x: xPosition, y: markerLayer.position.y)
-    CATransaction.commit()
+    CALayer.noAnimation {
+      markerLayer.position = CGPoint(x: xPosition, y: markerLayer.position.y)
+    }
   }
 
   func setupControlViewAnimation() {

--- a/Sharktopoda/View/Video/VideoWindow/VideoWindow.swift
+++ b/Sharktopoda/View/Video/VideoWindow/VideoWindow.swift
@@ -12,16 +12,19 @@ import SwiftUI
 
 final class VideoWindow: NSWindow {
   var windowData = WindowData()
-  
+
   /// Queue for playerTime observation
   let playerTimeQueue: DispatchQueue
+
+  /// Token for removing the periodic time observer
+  var periodicTimeObserverToken: Any?
 
   /// Background Task for resizing localizations
   var resizingTask: Task<(), Never>?
 
   /// Used by delegate to pause/resume playback after resizing
   var playerDirection: WindowData.PlayerDirection?
-  
+
   var showLocalizationsSubscription: AnyCancellable?
   
   init(for videoAsset: VideoAsset, with sharktopodaData: SharktopodaData) {
@@ -81,5 +84,36 @@ final class VideoWindow: NSWindow {
   
   func bringToFront() {
     makeKeyAndOrderFront(nil)
+  }
+
+  func cleanup() {
+    // Remove periodic time observer
+    if let token = periodicTimeObserverToken {
+      windowData.player.removeTimeObserver(token)
+      periodicTimeObserverToken = nil
+    }
+
+    // Remove NotificationCenter observer
+    NotificationCenter.default.removeObserver(self)
+
+    // Cancel Combine subscriptions
+    showLocalizationsSubscription?.cancel()
+    showLocalizationsSubscription = nil
+    windowData.timeSlider.playerTimeSubscription?.cancel()
+    windowData.timeSlider.playerTimeSubscription = nil
+
+    // Cancel any in-flight resizing task
+    resizingTask?.cancel()
+    resizingTask = nil
+
+    // Clear the player layer's reference to the player
+    windowData.playerView.nsPlayerView.playerLayer.player = nil
+
+    // Clear localization layers
+    windowData.playerView.clear()
+
+    // Stop the player
+    windowData.player.pause()
+    windowData.player.replaceCurrentItem(with: nil)
   }
 }

--- a/Sharktopoda/View/Video/VideoWindow/VideoWindow.swift
+++ b/Sharktopoda/View/Video/VideoWindow/VideoWindow.swift
@@ -99,8 +99,8 @@ final class VideoWindow: NSWindow {
     // Cancel Combine subscriptions
     showLocalizationsSubscription?.cancel()
     showLocalizationsSubscription = nil
-    windowData.timeSlider.playerTimeSubscription?.cancel()
-    windowData.timeSlider.playerTimeSubscription = nil
+    windowData.timeSlider?.playerTimeSubscription?.cancel()
+    windowData.timeSlider?.playerTimeSubscription = nil
 
     // Cancel any in-flight resizing task
     resizingTask?.cancel()

--- a/Sharktopoda/View/Video/VideoWindow/VideoWindowDelegate.swift
+++ b/Sharktopoda/View/Video/VideoWindow/VideoWindowDelegate.swift
@@ -10,8 +10,10 @@ import SwiftUI
 
 extension VideoWindow: NSWindowDelegate {
   func windowWillClose(_ notification: Notification) {
+    cleanup()
+
     guard let sharktopodaData = UDP.sharktopodaData else { return }
-    
+
     sharktopodaData.releaseWindow(self)
   }
   

--- a/Sharktopoda/View/Video/VideoWindow/VideoWindowPlayerObserver.swift
+++ b/Sharktopoda/View/Video/VideoWindow/VideoWindowPlayerObserver.swift
@@ -9,7 +9,7 @@ import AVFoundation
 
 extension VideoWindow {
   func setPlayerObserver(_ pollingInterval: CMTime) {
-    windowData.player.addPeriodicTimeObserver(forInterval: pollingInterval,
+    periodicTimeObserverToken = windowData.player.addPeriodicTimeObserver(forInterval: pollingInterval,
                                               queue: playerTimeQueue) { [weak self] time in
       guard let windowData = self?.windowData else { return }
 


### PR DESCRIPTION
On Tahoe, I was running into two issues:

1. The first video opened seemed to work fine, but opening a second video would break time sync with the scrubber and the UDP client
2. When that was patched, time was syncing with the labels next to the scrubber, but not the scrubber or the UDP client.